### PR TITLE
Run make-docs as part of workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,10 @@ jobs:
       - uses: Eijebong/ap-actions/ap-tests@main
         with:
           apworld-path: keymasters_keep
-          ap-version: '0.6.1'
+          ap-version: '0.6.2'
           python-version: '3.12'
           checkout: 'false'
+      - name: Make docs
+        run: |
+          ln -s archipelago/.venv .venv
+          uv run python make_docs.py


### PR DESCRIPTION
This'll be almost as good as fuzzing, as it actually executes most of the GenerateTemplates codepaths.